### PR TITLE
reverted geo backup to original

### DIFF
--- a/config/azurerm/azurerm_postgresql_server.yml
+++ b/config/azurerm/azurerm_postgresql_server.yml
@@ -81,8 +81,8 @@ azurerm_postgresql_server:
                 to a paired data center. This provides better protection and ability
                 to restore your server in a different region in the event of a disaster.
                 This is not support for the Basic tier.
-            required: true
-            policy: true
+            required: false
+            policy: ''
             notes: ''
         create_mode:
             description: The creation mode. Can be used to restore or replicate existing


### PR DESCRIPTION
Need to have CCoE require mandate to have geo-redundant backup enabled